### PR TITLE
Code refactoring

### DIFF
--- a/src/Decoder/Decoder.php
+++ b/src/Decoder/Decoder.php
@@ -9,6 +9,7 @@ use CBOR\OtherObject\OtherObjectManager;
 use CBOR\Tag\TagObjectManager;
 use Herald\GreenPass\GreenPass;
 use Mhauri\Base45;
+use Herald\GreenPass\Exceptions\NoCertificateListException;
 
 class Decoder
 {
@@ -107,8 +108,7 @@ class Decoder
         $uri = "$current_dir/../../assets/dsc.json";
 
         // We decode the JSON object we received
-        $certificates = json_decode(file_get_contents($uri), true, 512, JSON_THROW_ON_ERROR);
-        return $certificates;
+        return json_decode(file_get_contents($uri), true, 512, JSON_THROW_ON_ERROR);
     }
 
     // Retrieve from RESUME-TOKEN KID
@@ -154,8 +154,9 @@ class Decoder
         if ($info['http_code'] == 200) {
             $list[$headers_arr['X-KID']] = $body;
             return static::retrieveCertificateFromList($list, $headers_arr['X-RESUME-TOKEN']);
-        } else
+        } else {
             return $list;
+        }
     }
 
     private static function validateKidCountry(array $cbor, $certificates)
@@ -206,8 +207,9 @@ class Decoder
         }
 
         foreach ($certificates as $kid => $data) {
-            if ($keyId == $kid)
+            if ($keyId == $kid){
                 return $data;
+            }
         }
 
         // If no public key is found, throw an exception
@@ -243,7 +245,7 @@ class Decoder
                     fclose($fp);
                     $certs_obj = json_decode($json_certs);
                 } else {
-                    throw new \Exception('Invalid certificates list');
+                    throw new NoCertificateListException();
                 }
             } else {
                 $fp = fopen($uri, 'r');

--- a/src/Exceptions/NoCertificateListException.php
+++ b/src/Exceptions/NoCertificateListException.php
@@ -1,0 +1,18 @@
+<?php
+namespace Herald\GreenPass\Exceptions;
+
+use Throwable;
+
+/**
+ *
+ * @url https://github.com/ehn-dcc-development/ehn-dcc-valuesets/blob/main/disease-agent-targeted.json
+ */
+class NoCertificateListException extends \Exception
+{
+    public function __construct($message = null, $code = 0, Throwable $previous = null) {
+        if(empty($message)){
+            $message = "Invalid certificates list";
+        }
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/GreenPassEntities/DiseaseAgent.php
+++ b/src/GreenPassEntities/DiseaseAgent.php
@@ -25,6 +25,9 @@ abstract class DiseaseAgent
             case "840539006":
                 return new Covid19();
                 break;
+            case "placeholder_for_other_code":
+                return null;
+                break;
             default:
                 return "";
         }

--- a/src/Validation/Covid19/ValidationRules.php
+++ b/src/Validation/Covid19/ValidationRules.php
@@ -35,6 +35,12 @@ class ValidationRules
         switch ($locale) {
             case "it_IT":
                 $uri = "https://get.dgc.gov.it/v1/dgc/settings";
+                break;
+            case "other_country":
+                $uri = "set_country_uri_there";
+                break;
+            default:
+                throw new \InvalidArgumentException("No country selected");
         }
         $res = $client->request('GET', $uri);
 


### PR DESCRIPTION
Define and throw a dedicated exception instead of using a generic one.
Add curly braces around the nested statement(s).
Add a "case default" clause to this "switch" statement.

verifyCert: This method has 24 returns, which is more than the 3 allowed.
verifyCert: Refactor this function to reduce its Cognitive Complexity from 49 to the 15 allowed.