### PR TITLE
Added debug function

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ E' necessario settare i permessi della cartella `sdk_repo_folder\assets` in modo
 il webserver possa leggere, creare ed editare i file contenuti in essa.
 
 Nel caso in cui non fosse possibile cambiare i permessi della cartella,
-dalla release `1.0.5` esiste la possibilità di modificare il path di salvataggio dei 
+dalla release `1.0.5` esiste la possibilità di modificare il path di salvataggio dei
 file, vedi [Cache Folder](#cache-folder).
 
 
@@ -78,6 +78,10 @@ use Herald\GreenPass\Utils\CertificateValidator;
 
 $gp_string = 'HC1:6BF.......';
 $gp_reader = new CertificateValidator($gp_string);
+
+// Debug (Commentare in Produzione)
+$gp_reader->debug = True;
+
 $gp_info = $gp_reader->getCertificateSimple();
 
 // Mostro la struttura dell'esito validazione
@@ -97,7 +101,7 @@ stato della verifica del DCC.
 
 ## Cache Folder
 
-Dalla release `1.0.5` esiste la possilità di modificare il path di salvataggio dei 
+Dalla release `1.0.5` esiste la possilità di modificare il path di salvataggio dei
 file, utilizzando il metodo `overrideCacheFilePath` della classe `FileUtils`:
 
 ```php

--- a/src/Utils/CertificateValidator.php
+++ b/src/Utils/CertificateValidator.php
@@ -11,18 +11,24 @@ class CertificateValidator
 {
 
     private $greenPassSimple;
-    
+
     private $scanMode;
+
+    public $debug;
 
     public function __construct(String $qrCodeText, String $scanMode = ValidationScanMode::CLASSIC_DGP)
     {
         $this->scanMode = $scanMode;
+        $this->debug = False;
         try{
             $greenPass = Decoder::qrcode($qrCodeText);
             $person = new SimplePerson($greenPass->holder->standardisedSurname, $greenPass->holder->surname, $greenPass->holder->standardisedForename, $greenPass->holder->forename);
-            
+
             $this->greenPassSimple = new CertificateSimple($person, $greenPass->holder->dateOfBirth, $greenPass->checkValid($this->scanMode));
         }catch (\Exception $e){
+            if ($this->debug){
+              echo($e);
+            }
             $this->greenPassSimple = new CertificateSimple(null, null, ValidationStatus::NOT_EU_DCC);
         }
     }

--- a/src/Utils/CertificateValidator.php
+++ b/src/Utils/CertificateValidator.php
@@ -27,7 +27,7 @@ class CertificateValidator
             $this->greenPassSimple = new CertificateSimple($person, $greenPass->holder->dateOfBirth, $greenPass->checkValid($this->scanMode));
         }catch (\Exception $e){
             if ($this->debug){
-              echo($e);
+              echo $e;
             }
             $this->greenPassSimple = new CertificateSimple(null, null, ValidationStatus::NOT_EU_DCC);
         }


### PR DESCRIPTION
I've noticed that the class CertificateValidator if there are errors simply throws the NOT_EU_DCC exception.

In order to get more informations on errors during development I've added a debug function to the class CertificateValidator.
The constructors sets is as False but you can turn it on by passing the parameter True when the class is instantiated. 

When enabled if an exception is trigger the error string will be echoed in the output.