### PR TITLE
Updated VerificaC19DB.php

### DIFF
--- a/src/Utils/VerificaC19DB.php
+++ b/src/Utils/VerificaC19DB.php
@@ -93,20 +93,13 @@ class VerificaC19DB
     public function addAllRevokedUcviToUcviList(array $revokedUcvi)
     {
         $this->pdo->beginTransaction();
-        $insert_values = array();
         $sql = 'INSERT OR IGNORE INTO ucvi(revokedUcvi) VALUES (?)';
         $stmt = $this->pdo->prepare($sql);
 
         foreach ($revokedUcvi as $d) {
-            $question_marks[] = '(' . $this->placeholders('?', is_array($d) ? sizeof($d) : 1) . ')';
-            if (is_array($d)) {
-                $insert_values = array_merge($insert_values, array_values($d));
-            } else {
-                $insert_values[] = $d;
-            }
             $stmt->execute([$d]);
         }
-        
+
         $this->pdo->commit();
     }
 

--- a/src/Utils/VerificaC19DB.php
+++ b/src/Utils/VerificaC19DB.php
@@ -97,22 +97,12 @@ class VerificaC19DB
         $stmt = $this->pdo->prepare($sql);
 
         foreach ($revokedUcvi as $d) {
-            $stmt->execute([$d]);
+            $stmt->execute([
+                $d
+            ]);
         }
 
         $this->pdo->commit();
-    }
-
-    private function placeholders($text, $count = 0, $separator = ",")
-    {
-        $result = array();
-        if ($count > 0) {
-            for ($x = 0; $x < $count; $x ++) {
-                $result[] = $text;
-            }
-        }
-
-        return implode($separator, $result);
     }
 
     public function removeRevokedUcviFromUcviList($revokedUcvi)

--- a/src/Utils/VerificaC19DB.php
+++ b/src/Utils/VerificaC19DB.php
@@ -94,6 +94,9 @@ class VerificaC19DB
     {
         $this->pdo->beginTransaction();
         $insert_values = array();
+        $sql = 'INSERT OR IGNORE INTO ucvi(revokedUcvi) VALUES (?)';
+        $stmt = $this->pdo->prepare($sql);
+
         foreach ($revokedUcvi as $d) {
             $question_marks[] = '(' . $this->placeholders('?', is_array($d) ? sizeof($d) : 1) . ')';
             if (is_array($d)) {
@@ -101,11 +104,9 @@ class VerificaC19DB
             } else {
                 $insert_values[] = $d;
             }
+            $stmt->execute([$d]);
         }
-        $sql = 'INSERT OR IGNORE INTO ucvi(revokedUcvi) VALUES ' . implode(',', $question_marks);
-
-        $stmt = $this->pdo->prepare($sql);
-        $stmt->execute($insert_values);
+        
         $this->pdo->commit();
     }
 


### PR DESCRIPTION
The function addAllRevokedUcviToUcviList uses a single insert query with a very large amount of parameters. This can cause an error during its execution due to the amount of data being processed in a single instance.
As modified the function will split the data and launch one insert at a time, thus avoiding errors during the execution.