### PR TITLE
fix download revoked list

### DIFF
--- a/src/Validation/Covid19/CertificateRevocationList.php
+++ b/src/Validation/Covid19/CertificateRevocationList.php
@@ -40,7 +40,7 @@ class CertificateRevocationList
     {
         $uri = FileUtils::getCacheFilePath(self::DRL_STATUS_FILE);
         if (! file_exists($uri)) {
-            $json = $this->saveCurrentStatus(1, 0, self::DRL_STATUS_VALID);
+            $json = $this->saveCurrentStatus(1, 0, self::DRL_STATUS_NEED_VALIDATION);
         } else {
             $json = FileUtils::readDataFromFile($uri);
         }


### PR DESCRIPTION
the file status was created in validity:"VALID". 
If the download failed the validity stay valid and to update the status file must attend the next day