### PR TITLE
feature: work scan mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,18 +141,18 @@ Dalla release `1.2.3` è possibile utilizzare un proxy per le chiamate agli endp
 Herald\GreenPass\Utils\EndpointService::setProxy("https://username:password@192.168.0.1:8000");
 ```
 ## Scan Mode
-Dalla versione `1.0.5` è necessario definire una delle due modalità di verifica della Certificazione verde Covid-19: BASE o RAFFORZATA.
-Dalla versione `1.2.0` è possibile definire una nuova modalità, BOOSTER.
+E' necessario definire una modalità di verifica della Certificazione verde Covid-19, come da elenco:
 
-* Tipologia BASE: l'sdk considera valide le certificazioni verdi generate da vaccinazione, da guarigione, da tampone.
-* Tipologia RAFFORZATA: l'sdk considera valide solo le certificazioni verdi generate da vaccinazione o da guarigione.
-* Tipologia BOOSTER: l'sdk app considera valide le certificazioni verdi generate dopo dose di richiamo vaccinale. Considera valide, inoltre, le certificazioni verdi generate dopo ciclo vaccinale primario o guarigione con la contestuale presentazione di un documento, cartaceo o digitale, che attesti l’esito negativo di un test al SARS-CoV-2.
+* Tipologia `BASE`: l'sdk considera valide le certificazioni verdi generate da vaccinazione, da guarigione, da tampone.
+* Tipologia `RAFFORZATA`: l'sdk considera valide solo le certificazioni verdi generate da vaccinazione o da guarigione.
+* Tipologia `BOOSTER`: l'sdk app considera valide le certificazioni verdi generate dopo dose di richiamo vaccinale. Considera valide, inoltre, le certificazioni verdi generate dopo ciclo vaccinale primario o guarigione con la contestuale presentazione di un documento, cartaceo o digitale, che attesti l’esito negativo di un test al SARS-CoV-2.
+* Tipologia `WORK`: l'sdk determina il controllo da effettuare per gli accessi ai luoghi di lavoro con mix obbligo vaccinale (>= 50 anni) e non (<50 anni). Le prescrizioni normative relative all'estensione dell'obbligo vaccinale in base all'età si applicano anche a coloro, che compiano il 50° anno di età in data successiva a quelle di entrata in vigore delle relative disposizioni, fermo l'attuale termine del 15 giugno 2022 (ex Art.1 comma 1 DL n.1 07/01/2022), ma sono comunque effettive dal compimento del 50° anno d'età.
 
-Indicazioni di dettaglio sulle attività consentite senza/con green pass BASE, RAFFORZATO, BOOSTER (link https://www.governo.it/sites/governo.it/files/documenti/documenti/Notizie-allegati/tabella_attivita_consentite.pdf)
+Indicazioni di dettaglio sulle attività consentite senza/con green pass `BASE`, `RAFFORZATO`, `BOOSTER` (link https://www.governo.it/sites/governo.it/files/documenti/documenti/Notizie-allegati/tabella_attivita_consentite.pdf)
 
 Per selezionare la tipologia, è possibile passare al costruttore del validatore un parametro di tipo `Herald\GreenPass\Validation\Covid19\ValidationScanMode`.
 
-Nel caso in cui non venisse scelto, viene impostata di default la tipologia BASE.
+Nel caso in cui non venisse scelto, viene impostata di default la tipologia `BASE`.
 
 ```php
 // set scan mode to 3G (BASE)
@@ -161,6 +161,8 @@ $scanMode = ValidationScanMode::CLASSIC_DGP;
 $scanMode = ValidationScanMode::SUPER_DGP;
 // or set scan mode to BOOSTED
 $scanMode = ValidationScanMode::BOOSTER_DGP;
+// or set scan mode to WORK
+$scanMode = ValidationScanMode::WORK_DGP;
 
 $gp_reader = new CertificateValidator($gp_string, $scanMode);
 ```

--- a/src/Validation/Covid19/GreenPassCovid19Checker.php
+++ b/src/Validation/Covid19/GreenPassCovid19Checker.php
@@ -52,7 +52,7 @@ class GreenPassCovid19Checker
                 return ValidationStatus::NOT_VALID;
             }
 
-            return self::verifyTestResults($cert, $data_oggi);
+            return self::verifyTestResults($cert, $data_oggi, $scanMode, $greenPass->holder->dateOfBirth);
         }
 
         // guarigione avvenuta
@@ -152,7 +152,7 @@ class GreenPassCovid19Checker
         return ValidationStatus::NOT_RECOGNIZED;
     }
 
-    private static function verifyTestResults(TestResult $cert, \DateTime $validation_date)
+    private static function verifyTestResults(TestResult $cert, \DateTime $validation_date, string $scanMode, \DateTimeImmutable $dob)
     {
         if ($cert->result == TestResultType::DETECTED) {
             return ValidationStatus::NOT_VALID;
@@ -172,7 +172,7 @@ class GreenPassCovid19Checker
                 return ValidationStatus::EXPIRED;
             }
 
-            return ValidationStatus::VALID;
+            return self::checkVaccineMandatoryAge($validation_date, $scanMode, $dob) ? ValidationStatus::NOT_VALID : ValidationStatus::VALID;
         }
 
         if ($cert->type == TestType::RAPID) {
@@ -189,7 +189,7 @@ class GreenPassCovid19Checker
                 return ValidationStatus::EXPIRED;
             }
 
-            return ValidationStatus::VALID;
+            return self::checkVaccineMandatoryAge($validation_date, $scanMode, $dob) ? ValidationStatus::NOT_VALID : ValidationStatus::VALID;
         }
 
         return ValidationStatus::NOT_RECOGNIZED;
@@ -269,6 +269,17 @@ class GreenPassCovid19Checker
                     return true;
                 }
             }
+        }
+
+        return false;
+    }
+
+    private static function checkVaccineMandatoryAge(\DateTime $validation_date, string $scanMode, \DateTimeImmutable $dob)
+    {
+        $age = $dob->diff($validation_date)->y;
+
+        if ($scanMode == ValidationScanMode::WORK_DGP && $age >= ValidationRules::VACCINE_MANDATORY_AGE) {
+            return true;
         }
 
         return false;

--- a/src/Validation/Covid19/ValidationRules.php
+++ b/src/Validation/Covid19/ValidationRules.php
@@ -1,33 +1,34 @@
 <?php
+
 namespace Herald\GreenPass\Validation\Covid19;
 
 class ValidationRules
 {
+    const RECOVERY_CERT_START_DAY = 'recovery_cert_start_day';
 
-    const RECOVERY_CERT_START_DAY = "recovery_cert_start_day";
-    
-    const RECOVERY_CERT_PV_START_DAY = "recovery_pv_cert_start_day";
+    const RECOVERY_CERT_PV_START_DAY = 'recovery_pv_cert_start_day';
 
-    const RECOVERY_CERT_END_DAY = "recovery_cert_end_day";
-    
-    const RECOVERY_CERT_PV_END_DAY = "recovery_pv_cert_end_day";
+    const RECOVERY_CERT_END_DAY = 'recovery_cert_end_day';
 
-    const MOLECULAR_TEST_START_HOUR = "molecular_test_start_hours";
+    const RECOVERY_CERT_PV_END_DAY = 'recovery_pv_cert_end_day';
 
-    const MOLECULAR_TEST_END_HOUR = "molecular_test_end_hours";
+    const MOLECULAR_TEST_START_HOUR = 'molecular_test_start_hours';
 
-    const RAPID_TEST_START_HOUR = "rapid_test_start_hours";
+    const MOLECULAR_TEST_END_HOUR = 'molecular_test_end_hours';
 
-    const RAPID_TEST_END_HOUR = "rapid_test_end_hours";
+    const RAPID_TEST_START_HOUR = 'rapid_test_start_hours';
 
-    const VACCINE_START_DAY_NOT_COMPLETE = "vaccine_start_day_not_complete";
+    const RAPID_TEST_END_HOUR = 'rapid_test_end_hours';
 
-    const VACCINE_END_DAY_NOT_COMPLETE = "vaccine_end_day_not_complete";
+    const VACCINE_START_DAY_NOT_COMPLETE = 'vaccine_start_day_not_complete';
 
-    const VACCINE_START_DAY_COMPLETE = "vaccine_start_day_complete";
+    const VACCINE_END_DAY_NOT_COMPLETE = 'vaccine_end_day_not_complete';
 
-    const VACCINE_END_DAY_COMPLETE = "vaccine_end_day_complete";
+    const VACCINE_START_DAY_COMPLETE = 'vaccine_start_day_complete';
 
-    const BLACK_LIST_UVCI = "black_list_uvci";
+    const VACCINE_END_DAY_COMPLETE = 'vaccine_end_day_complete';
 
+    const BLACK_LIST_UVCI = 'black_list_uvci';
+
+    const VACCINE_MANDATORY_AGE = 50;
 }

--- a/src/Validation/Covid19/ValidationScanMode.php
+++ b/src/Validation/Covid19/ValidationScanMode.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Herald\GreenPass\Validation\Covid19;
 
 /*
@@ -6,10 +7,11 @@ namespace Herald\GreenPass\Validation\Covid19;
  */
 class ValidationScanMode
 {
+    const SUPER_DGP = '2G';
 
-    const SUPER_DGP = "2G";
+    const CLASSIC_DGP = '3G';
 
-    const CLASSIC_DGP = "3G";
-    
-    const BOOSTER_DGP = "BOOSTED";
+    const BOOSTER_DGP = 'BOOSTED';
+
+    const WORK_DGP = 'WORK';
 }

--- a/tests/GreenPassCovid19CheckerTest.php
+++ b/tests/GreenPassCovid19CheckerTest.php
@@ -30,6 +30,8 @@ class GreenPassCovid19CheckerTest extends \PHPUnit\Framework\TestCase
 
     const DATE_50_YEARS = '-50 year';
 
+    const DATE_12_HOURS_AGO = '-12 hour';
+
     protected $data_oggi;
 
     protected function setUp(): void

--- a/tests/GreenPassCovid19CheckerTest.php
+++ b/tests/GreenPassCovid19CheckerTest.php
@@ -1,33 +1,34 @@
 <?php
+
 namespace Herald\GreenPass\Validation\Covid19;
 
-use Herald\GreenPass\GreenPass;
 use Herald\GreenPass\GPDataTest;
-use Herald\GreenPass\Decoder\Decoder;
+use Herald\GreenPass\GreenPass;
 
 /**
  * GreenPassCovid19Checker test case.
  */
 class GreenPassCovid19CheckerTest extends \PHPUnit\Framework\TestCase
 {
+    const DATE_IN_5_MONTHS = '+5 month';
 
-    const DATE_IN_5_MONTHS = "+5 month";
+    const DATE_A_MONTH_AGO = '-1 month';
 
-    const DATE_A_MONTH_AGO = "-1 month";
+    const DATE_5_MONTHS_AGO = '-5 month';
 
-    const DATE_5_MONTHS_AGO = "-5 month";
+    const DATE_7_MONTHS_AGO = '-7 month';
 
-    const DATE_7_MONTHS_AGO = "-7 month";
+    const DATE_TOMORROW = '+1 day';
 
-    const DATE_TOMORROW = "+1 day";
+    const DATE_A_DAY_AGO = '-1 day';
 
-    const DATE_A_DAY_AGO = "-1 day";
+    const DATE_5_DAYS_AGO = '-5 day';
 
-    const DATE_5_DAYS_AGO = "-5 day";
+    const DATE_20_DAYS_AGO = '-20 day';
 
-    const DATE_20_DAYS_AGO = "-20 day";
+    const DATE_MORE_THAN_A_YEAR = '-366 day';
 
-    const DATE_MORE_THAN_A_YEAR = "-366 day";
+    const DATE_50_YEARS = '-50 year';
 
     protected $data_oggi;
 
@@ -41,11 +42,11 @@ class GreenPassCovid19CheckerTest extends \PHPUnit\Framework\TestCase
     {
         // TEST CODICE DIVERSO DA C19
         $testgp = GPDataTest::$vaccine;
-        $testgp["v"][0]["tg"] = "00000000000000";
+        $testgp['v'][0]['tg'] = '00000000000000';
         $greenpass = new GreenPass($testgp);
 
         $esito = GreenPassCovid19Checker::verifyCert($greenpass);
-        $this->assertEquals("NOT_COVID_19", $esito);
+        $this->assertEquals('NOT_COVID_19', $esito);
     }
 
     protected function tearDown(): void
@@ -54,4 +55,3 @@ class GreenPassCovid19CheckerTest extends \PHPUnit\Framework\TestCase
         parent::tearDown();
     }
 }
-

--- a/tests/TamponeCheckerTest.php
+++ b/tests/TamponeCheckerTest.php
@@ -80,6 +80,20 @@ class TamponeCheckerTest extends GreenPassCovid19CheckerTest
 
         $esito = GreenPassCovid19Checker::verifyCert($greenpass, 'WORK');
         $this->assertEquals('VALID', $esito);
+
+        // fixed young date
+        $testgp['dob'] = '2000-01-01';
+        $greenpass = new GreenPass($testgp);
+
+        $esito = GreenPassCovid19Checker::verifyCert($greenpass, 'WORK');
+        $this->assertEquals('VALID', $esito);
+
+        // fixed old date
+        $testgp['dob'] = '1930-01-01';
+        $greenpass = new GreenPass($testgp);
+
+        $esito = GreenPassCovid19Checker::verifyCert($greenpass, 'WORK');
+        $this->assertEquals('NOT_VALID', $esito);
     }
 
     /**

--- a/tests/TamponeCheckerTest.php
+++ b/tests/TamponeCheckerTest.php
@@ -1,66 +1,99 @@
 <?php
+
 namespace Herald\GreenPass\Validation\Covid19;
 
-use Herald\GreenPass\GreenPass;
 use Herald\GreenPass\GPDataTest;
-use Herald\GreenPass\Decoder\Decoder;
-use Herald\GreenPass\Validation\Covid19\GreenPassCovid19CheckerTest;
+use Herald\GreenPass\GreenPass;
 
 /**
  * TamponeCheckerTest test case.
  */
 class TamponeCheckerTest extends GreenPassCovid19CheckerTest
 {
-
     /**
-     * Test tampone dopo 12 ore
+     * Test tampone dopo 12 ore.
      */
     public function testVerifyCertTampone()
     {
         $testgp = GPDataTest::$testresult;
 
-        $data_greenpass = $this->data_oggi->modify("-12 hour");
-        $testgp["t"][0]["sc"] = $data_greenpass->format(\DateTime::ATOM);
+        $data_greenpass = $this->data_oggi->modify('-12 hour');
+        $testgp['t'][0]['sc'] = $data_greenpass->format(\DateTime::ATOM);
         $greenpass = new GreenPass($testgp);
 
-        $esito = GreenPassCovid19Checker::verifyCert($greenpass, "3G");
-        $this->assertEquals("VALID", $esito);
+        $esito = GreenPassCovid19Checker::verifyCert($greenpass, '3G');
+        $this->assertEquals('VALID', $esito);
     }
 
     /**
-     * Test scan mode GreenPass
+     * Test scan mode GreenPass.
      */
     public function testScanModeTampone()
     {
         $testgp = GPDataTest::$testresult;
 
-        $data_greenpass = $this->data_oggi->modify("-12 hour");
-        $testgp["t"][0]["sc"] = $data_greenpass->format(\DateTime::ATOM);
+        $data_greenpass = $this->data_oggi->modify('-12 hour');
+        $testgp['t'][0]['sc'] = $data_greenpass->format(\DateTime::ATOM);
         $greenpass = new GreenPass($testgp);
 
-        $esito = GreenPassCovid19Checker::verifyCert($greenpass, "3G");
-        $this->assertEquals("VALID", $esito);
+        $esito = GreenPassCovid19Checker::verifyCert($greenpass, '3G');
+        $this->assertEquals('VALID', $esito);
 
-        $esito = GreenPassCovid19Checker::verifyCert($greenpass, "2G");
-        $this->assertEquals("NOT_VALID", $esito);
+        $esito = GreenPassCovid19Checker::verifyCert($greenpass, '2G');
+        $this->assertEquals('NOT_VALID', $esito);
 
-        $esito = GreenPassCovid19Checker::verifyCert($greenpass, "BOOSTED");
-        $this->assertEquals("NOT_VALID", $esito);
+        $esito = GreenPassCovid19Checker::verifyCert($greenpass, 'BOOSTED');
+        $this->assertEquals('NOT_VALID', $esito);
     }
 
     /**
-     * Test tampone dopo 120 ore
+     * Test work scan mode GreenPass.
+     */
+    public function testWorkScanModeTampone()
+    {
+        $testgp = GPDataTest::$testresult;
+
+        $data_greenpass = $this->data_oggi->modify('-12 hour');
+        $testgp['t'][0]['sc'] = $data_greenpass->format(\DateTime::ATOM);
+
+        $today_50_birthday = $this->data_oggi->modify(self::DATE_50_YEARS);
+
+        // birthday 50 years old
+        $testgp['dob'] = $today_50_birthday->format(\DateTime::ATOM);
+        $greenpass = new GreenPass($testgp);
+
+        $esito = GreenPassCovid19Checker::verifyCert($greenpass, 'WORK');
+        $this->assertEquals('NOT_VALID', $esito);
+
+        // the day after 50 years old birthday
+        $today_50_birthday_plus_one = $today_50_birthday->modify('-1 day');
+        $testgp['dob'] = $today_50_birthday_plus_one->format(\DateTime::ATOM);
+        $greenpass = new GreenPass($testgp);
+
+        $esito = GreenPassCovid19Checker::verifyCert($greenpass, 'WORK');
+        $this->assertEquals('NOT_VALID', $esito);
+
+        // the day before 50 years old birthday
+        $today_49_years_old = $today_50_birthday->modify('+1 day');
+        $testgp['dob'] = $today_49_years_old->format(\DateTime::ATOM);
+        $greenpass = new GreenPass($testgp);
+
+        $esito = GreenPassCovid19Checker::verifyCert($greenpass, 'WORK');
+        $this->assertEquals('VALID', $esito);
+    }
+
+    /**
+     * Test tampone dopo 120 ore.
      */
     public function testTamponeScaduto()
     {
         $testgp = GPDataTest::$testresult;
 
-        $data_greenpass = $this->data_oggi->modify("-120 hour");
-        $testgp["t"][0]["sc"] = $data_greenpass->format(\DateTime::ATOM);
+        $data_greenpass = $this->data_oggi->modify('-120 hour');
+        $testgp['t'][0]['sc'] = $data_greenpass->format(\DateTime::ATOM);
         $greenpass = new GreenPass($testgp);
 
-        $esito = GreenPassCovid19Checker::verifyCert($greenpass, "3G");
-        $this->assertEquals("EXPIRED", $esito);
+        $esito = GreenPassCovid19Checker::verifyCert($greenpass, '3G');
+        $this->assertEquals('EXPIRED', $esito);
     }
 }
-

--- a/tests/TamponeCheckerTest.php
+++ b/tests/TamponeCheckerTest.php
@@ -17,7 +17,7 @@ class TamponeCheckerTest extends GreenPassCovid19CheckerTest
     {
         $testgp = GPDataTest::$testresult;
 
-        $data_greenpass = $this->data_oggi->modify('-12 hour');
+        $data_greenpass = $this->data_oggi->modify(self::DATE_12_HOURS_AGO);
         $testgp['t'][0]['sc'] = $data_greenpass->format(\DateTime::ATOM);
         $greenpass = new GreenPass($testgp);
 
@@ -32,7 +32,7 @@ class TamponeCheckerTest extends GreenPassCovid19CheckerTest
     {
         $testgp = GPDataTest::$testresult;
 
-        $data_greenpass = $this->data_oggi->modify('-12 hour');
+        $data_greenpass = $this->data_oggi->modify(self::DATE_12_HOURS_AGO);
         $testgp['t'][0]['sc'] = $data_greenpass->format(\DateTime::ATOM);
         $greenpass = new GreenPass($testgp);
 
@@ -53,7 +53,7 @@ class TamponeCheckerTest extends GreenPassCovid19CheckerTest
     {
         $testgp = GPDataTest::$testresult;
 
-        $data_greenpass = $this->data_oggi->modify('-12 hour');
+        $data_greenpass = $this->data_oggi->modify(self::DATE_12_HOURS_AGO);
         $testgp['t'][0]['sc'] = $data_greenpass->format(\DateTime::ATOM);
 
         $today_50_birthday = $this->data_oggi->modify(self::DATE_50_YEARS);
@@ -66,7 +66,7 @@ class TamponeCheckerTest extends GreenPassCovid19CheckerTest
         $this->assertEquals('NOT_VALID', $esito);
 
         // the day after 50 years old birthday
-        $today_50_birthday_plus_one = $today_50_birthday->modify('-1 day');
+        $today_50_birthday_plus_one = $today_50_birthday->modify(self::DATE_A_DAY_AGO);
         $testgp['dob'] = $today_50_birthday_plus_one->format(\DateTime::ATOM);
         $greenpass = new GreenPass($testgp);
 
@@ -74,7 +74,7 @@ class TamponeCheckerTest extends GreenPassCovid19CheckerTest
         $this->assertEquals('NOT_VALID', $esito);
 
         // the day before 50 years old birthday
-        $today_49_years_old = $today_50_birthday->modify('+1 day');
+        $today_49_years_old = $today_50_birthday->modify(self::DATE_TOMORROW);
         $testgp['dob'] = $today_49_years_old->format(\DateTime::ATOM);
         $greenpass = new GreenPass($testgp);
 


### PR DESCRIPTION
Aggiunta della condizione di controllo scanMode50 per i DGC T (tampone) e della relativa tipologia di verifica Lavoro (disponibile come ulteriore scelta di modalità di scansione).

According to DL 1 07/01/2022 - Article 1, the requirements of the vaccination obligation based on age apply anyway to "those who have reached the age of 50" on validation checks.

Not yet to those who turn 50 in 2022, but are still 49 years old on validation date/time.

Therefore, the following arrangement for age-check with DGC type T could fit better such requirements :

```
   val age = LocalDate.now().year - LocalDate.parse(clearExtraTime(cert.dateOfBirth!!)).year
   val agem = LocalDate.now().monthValue - LocalDate.parse(clearExtraTime(cert.dateOfBirth!!)).monthValue
   val aged = LocalDate.now().dayOfMonth - LocalDate.parse(clearExtraTime(cert.dateOfBirth!!)).dayOfMonth

   if (age >= Const.VACCINE_MANDATORY_AGE && agem >= 0 && aged >= 0 && cert.scanMode == ScanMode.WORK) 
      CertificateStatus.NOT_VALID
   else CertificateStatus.VALID 

```

Additional checks for birthdate - in order to intercept those special cases where month/day or day are missing & avoid null exceptions - shouldn't be required owing to Italian DGC T compliance to DCC valueset schema for birthdates (ISO 8601)
See [note ](https://github.com/ministero-salute/it-dgc-verificac19-sdk-android/commit/a2186ae790df0a870298c294567ffe2535c27827#r63829753)on it-dgc-verificac19-sdk-android