### PR TITLE
feature: disabled WORK_DGP and SCHOOL_DGP in production

### DIFF
--- a/src/Utils/CertificateValidator.php
+++ b/src/Utils/CertificateValidator.php
@@ -3,10 +3,10 @@
 namespace Herald\GreenPass\Utils;
 
 use Herald\GreenPass\Decoder\Decoder;
-use Herald\GreenPass\Model\SimplePerson;
 use Herald\GreenPass\Model\CertificateSimple;
-use Herald\GreenPass\Validation\Covid19\ValidationStatus;
+use Herald\GreenPass\Model\SimplePerson;
 use Herald\GreenPass\Validation\Covid19\ValidationScanMode;
+use Herald\GreenPass\Validation\Covid19\ValidationStatus;
 
 class CertificateValidator
 {
@@ -14,14 +14,14 @@ class CertificateValidator
 
     private $scanMode;
 
-    public function __construct(String $qrCodeText, String $scanMode = ValidationScanMode::CLASSIC_DGP)
+    public function __construct(string $qrCodeText, string $scanMode = ValidationScanMode::CLASSIC_DGP)
     {
         $this->scanMode = $scanMode;
         try {
             $greenPass = Decoder::qrcode($qrCodeText);
 
             $debug = EnvConfig::isDebugEnabled();
-            $debugDisclaimer = "DISABLE-DEBUG-MODE-IN-PRODUCTION";
+            $debugDisclaimer = 'DISABLE-DEBUG-MODE-IN-PRODUCTION';
 
             $standardizedFamilyName = $debug ? $debugDisclaimer : $greenPass->holder->standardisedSurname;
             $familyName = $debug ? $debugDisclaimer : $greenPass->holder->surname;

--- a/src/Validation/Covid19/GreenPassCovid19Checker.php
+++ b/src/Validation/Covid19/GreenPassCovid19Checker.php
@@ -14,11 +14,15 @@ use Herald\GreenPass\GreenPassEntities\TestResultType;
 use Herald\GreenPass\GreenPassEntities\TestType;
 use Herald\GreenPass\GreenPassEntities\VaccinationDose;
 use Herald\GreenPass\Utils\EndpointService;
+use Herald\GreenPass\Utils\EnvConfig;
 
 class GreenPassCovid19Checker
 {
     public static function verifyCert(GreenPass $greenPass, string $scanMode = ValidationScanMode::CLASSIC_DGP)
     {
+        if (!EnvConfig::isDebugEnabled() && ($scanMode == ValidationScanMode::SCHOOL_DGP || $scanMode == ValidationScanMode::WORK_DGP)) {
+            throw new  \InvalidArgumentException('Unrelased scan mode, dont use in production');
+        }
         $cert = $greenPass->certificate;
 
         if (!self::verifyDiseaseAgent($cert->diseaseAgent)) {

--- a/tests/GreenPassCovid19CheckerTest.php
+++ b/tests/GreenPassCovid19CheckerTest.php
@@ -4,6 +4,7 @@ namespace Herald\GreenPass\Validation\Covid19;
 
 use Herald\GreenPass\GPDataTest;
 use Herald\GreenPass\GreenPass;
+use Herald\GreenPass\Utils\EnvConfig;
 
 /**
  * GreenPassCovid19Checker test case.
@@ -38,6 +39,7 @@ class GreenPassCovid19CheckerTest extends \PHPUnit\Framework\TestCase
     {
         parent::setUp();
         $this->data_oggi = new \DateTimeImmutable();
+        EnvConfig::enableDebugMode();
     }
 
     public function testVerifyC19Cert()


### PR DESCRIPTION
the official sdk has not yet released the WORK and SCHOOL scanmodes.
they can only be activated in debug mode to perform functional tests.
to use them, enable debug mode: EnvConfig::enableDebugMode()