### PR TITLE
fix: dgc/settings rules compliance

### DIFF
--- a/src/Validation/Covid19/GreenPassCovid19Checker.php
+++ b/src/Validation/Covid19/GreenPassCovid19Checker.php
@@ -144,7 +144,7 @@ class GreenPassCovid19Checker
     private static function getVaccineCustomDaysFromValidationRules(VaccinationDose $cert, string $scanMode, string $startEnd, bool $isBooster): int
     {
         $addDays = 0;
-        $ruleType = $cert->product;
+        $ruleType = ValidationRules::GENERIC_RULE;
         if ($isBooster) {
             $customCycle = self::CERT_BOOSTER;
         } else {

--- a/tests/RecoveryCheckerTest.php
+++ b/tests/RecoveryCheckerTest.php
@@ -153,7 +153,7 @@ class RecoveryCheckerTest extends GreenPassCovid19CheckerTest
         $greenpass = new GreenPass($testgp);
 
         $esito = GreenPassCovid19Checker::verifyCert($greenpass);
-        $this->assertEquals('VALID', $esito);
+        $this->assertEquals('NOT_VALID', $esito);
 
         // other scandmode use Italy validation rules
         $esito = GreenPassCovid19Checker::verifyCert($greenpass, ValidationScanMode::SUPER_DGP);


### PR DESCRIPTION
fix: the new settings for "full cycle", "recovery" and "booster dose" IT / not IT are online. The type is "GENERIC" for all of them.
test: modified the recovery test to match the settings rule "recovery_cert_end_day_NOT_IT" (current value: 180, default value: 270)