### PR TITLE
Fix today date

### DIFF
--- a/src/Validation/Covid19/GreenPassCovid19Checker.php
+++ b/src/Validation/Covid19/GreenPassCovid19Checker.php
@@ -34,7 +34,7 @@ class GreenPassCovid19Checker
             return ValidationStatus::NOT_COVID_19;
         }
 
-        $data_oggi = new \DateTime();
+        $data_oggi = new \DateTime(date("Ymd"));
 
         $certificateId = self::extractUVCI($greenPass);
 

--- a/src/Validation/Covid19/GreenPassCovid19Checker.php
+++ b/src/Validation/Covid19/GreenPassCovid19Checker.php
@@ -34,7 +34,7 @@ class GreenPassCovid19Checker
             return ValidationStatus::NOT_COVID_19;
         }
 
-        $data_oggi = new \DateTime(date("Ymd"));
+        $data_oggi = new \DateTime();
 
         $certificateId = self::extractUVCI($greenPass);
 

--- a/src/Validation/Covid19/RecoveryChecker.php
+++ b/src/Validation/Covid19/RecoveryChecker.php
@@ -49,7 +49,7 @@ class RecoveryChecker
             return ValidationStatus::NOT_VALID_YET;
         }
 
-        if ($this->validation_date > $endDate) {
+        if ($this->validation_date->date > $endDate) {
             return ValidationStatus::EXPIRED;
         }
 

--- a/src/Validation/Covid19/RecoveryChecker.php
+++ b/src/Validation/Covid19/RecoveryChecker.php
@@ -44,12 +44,13 @@ class RecoveryChecker
 
         $startDate = $certificateValidFrom->modify("+$startDaysToAdd days");
         $endDate = $certificateValidFrom->modify("+$endDaysToAdd days");
-
+        $endDate = $endDate->SetTime(23, 59);
+        
         if ($startDate > $this->validation_date) {
             return ValidationStatus::NOT_VALID_YET;
         }
 
-        if ($this->validation_date->date > $endDate) {
+        if ($this->validation_date > $endDate) {
             return ValidationStatus::EXPIRED;
         }
 

--- a/src/Validation/Covid19/VaccineChecker.php
+++ b/src/Validation/Covid19/VaccineChecker.php
@@ -129,11 +129,12 @@ class VaccineChecker
 
         $startDate = $vaccineDate->modify("+$startDaysToAdd days");
         $endDate = $vaccineDate->modify("+$endDaysToAdd days");
+        $endDate = $endDate->SetTime(23, 59);
 
         if ($this->validation_date < $startDate) {
             return ValidationStatus::NOT_VALID_YET;
         }
-        if ($this->validation_date->date > $endDate) {
+        if ($this->validation_date > $endDate) {
             return ValidationStatus::EXPIRED;
         }
         if (!MedicinalProduct::isEma($cert->product, $cert->country)) {
@@ -168,6 +169,8 @@ class VaccineChecker
         $startDate = $vaccineDate->modify("+$startDaysToAdd days");
         $endDate = $vaccineDate->modify("+$endDaysToAdd days");
         $extendedDate = $vaccineDate->modify("+$extendedDaysToAdd days");
+        $endDate = $endDate->SetTime(23, 59);
+        $extendedDate = $endDate->SetTime(23, 59);
 
         if ($cert->isNotComplete()) {
             if (!MedicinalProduct::isEma($cert->product, $cert->country)) {
@@ -175,7 +178,7 @@ class VaccineChecker
             }
             if ($this->validation_date < $startDate) {
                 $esito = ValidationStatus::NOT_VALID_YET;
-            } elseif ($this->validation_date->date > $endDate) {
+            } elseif ($this->validation_date > $endDate) {
                 $esito = ValidationStatus::EXPIRED;
             } else {
                 $esito = ValidationStatus::VALID;
@@ -183,7 +186,7 @@ class VaccineChecker
         } elseif ($cert->isBooster()) {
             if ($this->validation_date < $startDate) {
                 $esito = ValidationStatus::NOT_VALID_YET;
-            } elseif ($this->validation_date->date > $endDate) {
+            } elseif ($this->validation_date > $endDate) {
                 $esito = ValidationStatus::EXPIRED;
             } elseif (MedicinalProduct::isEma($cert->product, $cert->country)) {
                 $esito = ValidationStatus::VALID;
@@ -194,9 +197,9 @@ class VaccineChecker
             if (MedicinalProduct::isEma($cert->product, $cert->country)) {
                 if ($this->validation_date < $startDate) {
                     $esito = ValidationStatus::NOT_VALID_YET;
-                } elseif ($this->validation_date->date <= $endDate) {
+                } elseif ($this->validation_date <= $endDate) {
                     $esito = ValidationStatus::VALID;
-                } elseif ($this->validation_date->date <= $extendedDate) {
+                } elseif ($this->validation_date <= $extendedDate) {
                     $esito = ValidationStatus::TEST_NEEDED;
                 } else {
                     $esito = ValidationStatus::EXPIRED;
@@ -204,7 +207,7 @@ class VaccineChecker
             } else {
                 if ($this->validation_date < $startDate) {
                     $esito = ValidationStatus::NOT_VALID_YET;
-                } elseif ($this->validation_date->date <= $extendedDate) {
+                } elseif ($this->validation_date <= $extendedDate) {
                     $esito = ValidationStatus::TEST_NEEDED;
                 } else {
                     $esito = ValidationStatus::EXPIRED;
@@ -229,10 +232,12 @@ class VaccineChecker
 
         $startDate = $vaccineDate->modify("+$startDaysToAdd days");
         $endDate = $vaccineDate->modify("+$endDaysToAdd days");
+        $endDate = $endDate->SetTime(23, 59);
+
         if ($this->validation_date < $startDate) {
             return ValidationStatus::NOT_VALID_YET;
         }
-        if ($this->validation_date->date > $endDate) {
+        if ($this->validation_date > $endDate) {
             return ValidationStatus::EXPIRED;
         }
 
@@ -271,6 +276,7 @@ class VaccineChecker
 
         $startDate = $vaccineDate->modify("+$startDaysToAdd days");
         $endDate = $vaccineDate->modify("+$endDaysToAdd days");
+        $endDate = $endDate->setTime(23, 59);
 
         return $this->defaultValidationResults($startDate, $endDate);
     }
@@ -320,7 +326,7 @@ class VaccineChecker
         if ($this->validation_date < $startDate) {
             return ValidationStatus::NOT_VALID_YET;
         }
-        if ($this->validation_date->date > $endDate) {
+        if ($this->validation_date > $endDate) {
             return ValidationStatus::EXPIRED;
         }
         //Data valida, controllo tipologia

--- a/src/Validation/Covid19/VaccineChecker.php
+++ b/src/Validation/Covid19/VaccineChecker.php
@@ -133,7 +133,7 @@ class VaccineChecker
         if ($this->validation_date < $startDate) {
             return ValidationStatus::NOT_VALID_YET;
         }
-        if ($this->validation_date > $endDate) {
+        if ($this->validation_date->date > $endDate) {
             return ValidationStatus::EXPIRED;
         }
         if (!MedicinalProduct::isEma($cert->product, $cert->country)) {
@@ -175,7 +175,7 @@ class VaccineChecker
             }
             if ($this->validation_date < $startDate) {
                 $esito = ValidationStatus::NOT_VALID_YET;
-            } elseif ($this->validation_date > $endDate) {
+            } elseif ($this->validation_date->date > $endDate) {
                 $esito = ValidationStatus::EXPIRED;
             } else {
                 $esito = ValidationStatus::VALID;
@@ -183,7 +183,7 @@ class VaccineChecker
         } elseif ($cert->isBooster()) {
             if ($this->validation_date < $startDate) {
                 $esito = ValidationStatus::NOT_VALID_YET;
-            } elseif ($this->validation_date > $endDate) {
+            } elseif ($this->validation_date->date > $endDate) {
                 $esito = ValidationStatus::EXPIRED;
             } elseif (MedicinalProduct::isEma($cert->product, $cert->country)) {
                 $esito = ValidationStatus::VALID;
@@ -194,9 +194,9 @@ class VaccineChecker
             if (MedicinalProduct::isEma($cert->product, $cert->country)) {
                 if ($this->validation_date < $startDate) {
                     $esito = ValidationStatus::NOT_VALID_YET;
-                } elseif ($this->validation_date <= $endDate) {
+                } elseif ($this->validation_date->date <= $endDate) {
                     $esito = ValidationStatus::VALID;
-                } elseif ($this->validation_date <= $extendedDate) {
+                } elseif ($this->validation_date->date <= $extendedDate) {
                     $esito = ValidationStatus::TEST_NEEDED;
                 } else {
                     $esito = ValidationStatus::EXPIRED;
@@ -204,7 +204,7 @@ class VaccineChecker
             } else {
                 if ($this->validation_date < $startDate) {
                     $esito = ValidationStatus::NOT_VALID_YET;
-                } elseif ($this->validation_date <= $extendedDate) {
+                } elseif ($this->validation_date->date <= $extendedDate) {
                     $esito = ValidationStatus::TEST_NEEDED;
                 } else {
                     $esito = ValidationStatus::EXPIRED;
@@ -232,7 +232,7 @@ class VaccineChecker
         if ($this->validation_date < $startDate) {
             return ValidationStatus::NOT_VALID_YET;
         }
-        if ($this->validation_date > $endDate) {
+        if ($this->validation_date->date > $endDate) {
             return ValidationStatus::EXPIRED;
         }
 
@@ -320,7 +320,7 @@ class VaccineChecker
         if ($this->validation_date < $startDate) {
             return ValidationStatus::NOT_VALID_YET;
         }
-        if ($this->validation_date > $endDate) {
+        if ($this->validation_date->date > $endDate) {
             return ValidationStatus::EXPIRED;
         }
         //Data valida, controllo tipologia

--- a/src/Validation/Covid19/VaccineChecker.php
+++ b/src/Validation/Covid19/VaccineChecker.php
@@ -170,7 +170,7 @@ class VaccineChecker
         $endDate = $vaccineDate->modify("+$endDaysToAdd days");
         $extendedDate = $vaccineDate->modify("+$extendedDaysToAdd days");
         $endDate = $endDate->SetTime(23, 59);
-        $extendedDate = $endDate->SetTime(23, 59);
+        $extendedDate = $extendedDate->SetTime(23, 59);
 
         if ($cert->isNotComplete()) {
             if (!MedicinalProduct::isEma($cert->product, $cert->country)) {


### PR DESCRIPTION
There is a bug on validation in the last day of green pass validity.
If i take datetime now(21/02/2022 13:07:00) this is < of a endDate(21/02/2022 00:00:00) green pass validity and the status is expired.
This is an error because the the green pass id valid until 23:59 of the last day.
